### PR TITLE
Set `modifyindex` flag to use the documented name

### DIFF
--- a/command/kv_write.go
+++ b/command/kv_write.go
@@ -35,7 +35,7 @@ Options:
 func (c *KVWriteCommand) Run(args []string) int {
 	c.AddDataCenter()
 	flags := c.Meta.FlagSet()
-	flags.StringVar(&c.modifyIndex, "cas", "", "")
+	flags.StringVar(&c.modifyIndex, "modifyindex", "", "")
 	flags.StringVar(&c.dataFlags, "flags", "", "")
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 


### PR DESCRIPTION
The `kv-write` command is documented as accepting the `--modifyindex` flag, but I received an error when attempting to use it.

```
./consul-cli kv-write --modifyindex=0 key value
unknown flag: --modifyindex
```

The source expects `--cas` instead, which contradicts the documentation. I modified `kv-write` to use the documented flag.
