### PR TITLE
Access consul using certificates if provided

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -44,6 +44,7 @@ func Init(name, version string) *Cmd {
 	c.root.PersistentFlags().BoolVar(&c.consul.sslEnabled, "ssl", false, "Use HTTPS when talking to Consul")
 	c.root.PersistentFlags().BoolVar(&c.consul.sslVerify, "ssl-verify", true, "Verify certificates when connecting via SSL")
 	c.root.PersistentFlags().StringVar(&c.consul.sslCert, "ssl-cert", "", "Path to an SSL client certificate for authentication")
+	c.root.PersistentFlags().StringVar(&c.consul.sslKey, "ssl-key", "", "Path to an SSL client certificate key for authentication")
 	c.root.PersistentFlags().StringVar(&c.consul.sslCaCert, "ssl-ca-cert", "", "Path to a CA certificate file to validate the Consul server")
 	c.root.PersistentFlags().Var((*auth)(c.consul.auth), "auth", "The HTTP basic authentication username (and optional password) separated by a colon")
 	c.root.PersistentFlags().StringVar(&c.consul.token, "token", "", "The Consul ACL token")
@@ -60,9 +61,9 @@ func Init(name, version string) *Cmd {
 	c.initStatus()
 
 	versionCmd := &cobra.Command{
-		Use: "version",
+		Use:   "version",
 		Short: "Print version information",
-		Long: "Print version information",
+		Long:  "Print version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%s %s\n", name, version)
 			return nil

--- a/commands/consul.go
+++ b/commands/consul.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -116,6 +117,9 @@ func (c *Cmd) Client() (*consulapi.Client, error) {
 		config.Scheme = "https"
 
 		if csl.sslCert != "" {
+			if csl.sslKey == "" || csl.sslCaCert == "" {
+				return nil, errors.New("--ssl-key and --ssl-ca-cert must be provided in order to use certificates for authentication")
+			}
 			clientCert, err := tls.LoadX509KeyPair(csl.sslCert, csl.sslKey)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
After trying consul-cli I saw it was not making anything if --ssl-cert was provided.

This pull request adds --ssl-key too in order of TLS validation.
