### PR TITLE
add catalog deregister command

### DIFF
--- a/commands/catalog.go
+++ b/commands/catalog.go
@@ -1,8 +1,6 @@
 package commands
 
-import (
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 type Catalog struct {
 	*Cmd
@@ -25,6 +23,7 @@ func (root *Cmd) initCatalog() {
 	c.AddNodesSub(catalogCmd)
 	c.AddServiceSub(catalogCmd)
 	c.AddServicesSub(catalogCmd)
+	c.AddDeregisterSub(catalogCmd)
 
 	c.AddCommand(catalogCmd)
 }

--- a/commands/catalog_deregister.go
+++ b/commands/catalog_deregister.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/spf13/cobra"
+)
+
+func (c *Catalog) AddDeregisterSub(cmd *cobra.Command) {
+	deregisterCmd := &cobra.Command{
+		Use:   "deregister <serviceId> <nodeName>",
+		Short: "Remove entry from the catalog",
+		Long:  "Remove entry from the catalog",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Deregister(args)
+		},
+	}
+
+	cmd.AddCommand(deregisterCmd)
+}
+
+func (c *Catalog) Deregister(args []string) error {
+	switch {
+	case len(args) == 0:
+		return fmt.Errorf("No service id specified")
+	case len(args) == 1:
+		return fmt.Errorf("No node name specified")
+	case len(args) > 2:
+		return fmt.Errorf("Only pair of service id / node name is allowed")
+	}
+
+	cdo := &consulapi.CatalogDeregistration{
+		ServiceID: args[0],
+		Node:      args[1],
+	}
+
+	client, err := c.Catalog()
+	if err != nil {
+		return err
+	}
+
+	writeOpts := c.WriteOptions()
+
+	_, err = client.Deregister(cdo, writeOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
If you try to register a service like this, you can see that you cannot deregister it using the command "consul-cli service deregister redis1", but you can deregister it with the new command that I added.

```
cat >test <<EOF
{
  "Datacenter": "dc1",
  "Node": "foobar",
  "Address": "192.168.10.10",
  "Service": {
    "ID": "redis1",
    "Service": "redis",
    "Tags": [
      "master",
      "v1"
    ],
    "Address": "127.0.0.1",
    "TaggedAddresses": {
      "wan": "127.0.0.1"
    },
    "Port": 8000
  },
  "Check": {
    "Node": "foobar",
    "CheckID": "service:redis1",
    "Name": "Redis health check",
    "Notes": "Script based health check",
    "Status": "passing",
    "ServiceID": "redis1"
  }
}
EOF
```

```
curl -X PUT -d @test http://localhost:8500/v1/catalog/register
echo "This shows the service was registered"
consul-cli catalog service redis
```

```
echo "Try to deregister the service, and it does not work"
consul-cli service deregister redis1
consul-cli catalog service redis
```

```
echo "Use the catalog deregister command, and the service is gone"
~/git/godev/src/github.com/CiscoCloud/consul-cli/consul-cli catalog deregister redis1 foobar
consul-cli catalog service redis
```
