### PR TITLE
Add quiet flag.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -49,6 +49,7 @@ func Init(name, version string) *Cmd {
 	c.root.PersistentFlags().Var((*auth)(c.consul.auth), "auth", "The HTTP basic authentication username (and optional password) separated by a colon")
 	c.root.PersistentFlags().StringVar(&c.consul.token, "token", "", "The Consul ACL token")
 	c.root.PersistentFlags().StringVar(&c.consul.tokenFile, "token-file", "", "Path to file containing Consul ACL token")
+	c.root.PersistentFlags().BoolVarP(&c.root.SilenceUsage, "quiet", "q", false, "Don't show usage on error")
 
 	c.initAcl()
 	c.initAgent()

--- a/commands/consul.go
+++ b/commands/consul.go
@@ -24,6 +24,7 @@ type consul struct {
 	tokenFile  string
 	auth       *auth
 	tlsConfig  *tls.Config
+	quiet      bool
 
 	dc        string
 	waitIndex uint64


### PR DESCRIPTION
Displaying usage on errors is noisy when the usage is correct but Consul returned an error for some other reason. It can be especially noisy int he output of scripts.

The `quiet` flag suppresses usage output on errors.
