### PR TITLE
Terminate all JSON output with a newline

### DIFF
--- a/commands/output.go
+++ b/commands/output.go
@@ -32,6 +32,13 @@ func (c *Cmd) OutputJSON(v interface{}, prettyFlag bool) error {
 
 	fmt.Fprintf(c.Out, string(jsonRaw))
 
+	jsonStr := string(jsonRaw)
+	if strings.HasSuffix(jsonStr, "\n") {
+		fmt.Fprintf(c.Out, jsonStr)
+	} else {
+		fmt.Fprintf(c.Out, jsonStr+"\n")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
I think it would be nice if the output always ended with a newline. It's weird
when it doesn't because the next prompt starts on the same line as the last
line of output and that just doesn't look great. Also it's nice to have the
output end with a newline because then you can redirect to a file and have that
file adhere to POSIX standards - e.g.:
- http://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline

Fixes: GH-23
### Before

```
marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$ consul-cli catalog services
{
  "aptly": [
    "develop"
  ],
  "consul": [],
  "vault": [
    "develop",
    "vault"
  ]
}marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$

marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$ echo "*** BEGIN services ***"; consul-cli catalog services; echo "*** END services ***"
*** BEGIN services ***
{
  "aptly": [
    "develop"
  ],
  "consul": [],
  "vault": [
    "develop",
    "vault"
  ]
}*** END services ***
```

Note how in the first example, the prompt appears on the same line as the last closing brace and in the second example, the `*** END services ***` appears immediately after the last closing brace.
### After

```
marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$ bin/consul-cli catalog services
{
  "aptly": [
    "develop"
  ],
  "consul": [],
  "vault": [
    "develop",
    "vault"
  ]
}
marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$

marca@marca-mac2:~/go/src/github.com/CiscoCloud/consul-cli$ echo "*** BEGIN services ***"; bin/consul-cli catalog services; echo "*** END services ***"
*** BEGIN services ***
{
  "aptly": [
    "develop"
  ],
  "consul": [],
  "vault": [
    "develop",
    "vault"
  ]
}
*** END services ***
```
