### PR TITLE
Fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine
+FROM golang:alpine
 
 MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ Command line interface to [Consul HTTP API](https://consul.io/docs/agent/http.ht
 | [service](https://github.com/CiscoCloud/consul-cli/wiki/Service) | Consul /agent/service endpoint
 | [session](https://github.com/CiscoCloud/consul-cli/wiki/Session) | Consul /session endpoint
 | [status](https://github.com/CiscoCloud/consul-cli/wiki/Status) | Consul /status endpoint
+
+## Build Docker image
+
+```
+$ docker build -t cmshub-cli .
+```


### PR DESCRIPTION
```
# github.com/CiscoCloud/consul-cli
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status
```