### PR TITLE
#54 - Fix issues with SSL Authentication

### DIFF
--- a/action/consul.go
+++ b/action/consul.go
@@ -165,7 +165,7 @@ func (c *consul) newClient() (*consulapi.Client, error) {
 		transport := new(http.Transport)
 
 		if c.sslCert != "" {
-			if c.sslKey != "" {
+			if c.sslKey == "" {
 				return nil, errors.New("--ssl-key must be provided in order to use certificates for authentication")
 			}
 			clientCert, err := tls.LoadX509KeyPair(c.sslCert, c.sslKey)
@@ -195,7 +195,7 @@ func (c *consul) newClient() (*consulapi.Client, error) {
 		}
 
 		transport.TLSClientConfig = tlsConfig
-		config.HttpClient.Transport = transport
+		config.Transport = transport
 	}
 
 	// Auth handling


### PR DESCRIPTION

Inverted `if` logic complained that no ssl-key was supplied if one was

Initialize the transport correctly.