### PR TITLE
Add a `--header` flag to `check register` and `service register` commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 
 go:
   - 1.8.x
-  - tip
+  - 1.10.x
 
 go_import_path: github.com/mantl/consul-cli
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 
 go:
   - 1.8.x
+  - 1.10.x
 
 go_import_path: github.com/mantl/consul-cli
 
@@ -10,7 +11,7 @@ install:
   - curl https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip -o consul.zip
   - unzip consul.zip
   - go get -v github.com/Masterminds/glide
-  - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/v0.12.3 && go install && cd -
+  - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/v0.13.2 && go install && cd -
   - glide install
   - make vendor
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ go:
 
 go_import_path: github.com/mantl/consul-cli
 
-install: 
+install:
+  - curl https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip -o consul.zip
+  - unzip consul.zip
   - go get -v github.com/Masterminds/glide
   - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/v0.12.3 && go install && cd -
   - glide install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 go:
   - 1.8.x
   - 1.10.x
+  - tip
 
 go_import_path: github.com/mantl/consul-cli
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ go:
 
 go_import_path: github.com/mantl/consul-cli
 
-env:
-  global:
-    - PATH="$TRAVIS_BUILD_DIR:$PATH"
-
 install:
   - curl https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip -o consul.zip
   - unzip consul.zip
@@ -18,4 +14,4 @@ install:
   - glide install
   - make vendor
 
-script: make test
+script: env PATH="$TRAVIS_BUILD_DIR:$PATH" make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ language: go
 
 go:
   - 1.8.x
-  - 1.10.x
 
 go_import_path: github.com/mantl/consul-cli
+
+env:
+  global:
+    - PATH="$TRAVIS_BUILD_DIR:$PATH"
 
 install:
   - curl https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip -o consul.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 
 go:
-  - 1.7.x
+  - 1.8.x
   - tip
 
 go_import_path: github.com/mantl/consul-cli

--- a/action/check_register.go
+++ b/action/check_register.go
@@ -67,6 +67,7 @@ func (c *checkRegister) Run(args []string) error {
 			Notes:     c.check.notes,
 			AgentServiceCheck: consulapi.AgentServiceCheck{
 				HTTP:              c.check.http,
+				Header:            parseHeaders(c.check.headers),
 				TCP:               c.check.tcp,
 				Interval:          c.check.interval,
 				TTL:               c.check.ttl,

--- a/action/check_register.go
+++ b/action/check_register.go
@@ -46,9 +46,6 @@ func (c *checkRegister) Run(args []string) error {
 		if c.check.http != "" {
 			checkCount = checkCount + 1
 		}
-		if c.check.script != "" {
-			checkCount = checkCount + 1
-		}
 		if c.check.ttl != "" {
 			checkCount = checkCount + 1
 		}
@@ -57,7 +54,7 @@ func (c *checkRegister) Run(args []string) error {
 		}
 
 		if checkCount > 1 {
-			return fmt.Errorf("Only one of --http, --script, --tcp or --ttl can be specified")
+			return fmt.Errorf("Only one of --http, --tcp or --ttl can be specified")
 		}
 
 		check = consulapi.AgentCheckRegistration{

--- a/action/check_register.go
+++ b/action/check_register.go
@@ -66,7 +66,6 @@ func (c *checkRegister) Run(args []string) error {
 			ServiceID: c.serviceId,
 			Notes:     c.check.notes,
 			AgentServiceCheck: consulapi.AgentServiceCheck{
-				Script:            c.check.script,
 				HTTP:              c.check.http,
 				TCP:               c.check.tcp,
 				Interval:          c.check.interval,

--- a/action/config.go
+++ b/action/config.go
@@ -38,7 +38,6 @@ type check struct {
 	http       string
 	headers    []string
 	tcp        string
-	script     string
 	ttl        string
 	interval   string
 	notes      string
@@ -79,7 +78,6 @@ func (c *config) addCheckFlags(f *flag.FlagSet) {
 	ssv.isCSV = false
 	f.Var(ssv, "header", "Header to be sent with HTTP Requests. Can be specified multiple times.")
 	f.StringVar(&c.check.tcp, "tcp", "", "A TCP URL to connect to every interval")
-	f.StringVar(&c.check.script, "script", "", "A script to run every interval")
 	f.StringVar(&c.check.ttl, "ttl", "", "Fail if TTL expires before service checks in")
 	f.StringVar(&c.check.interval, "interval", "", "Interval between checks")
 	f.StringVar(&c.check.notes, "notes", "", "Description of the check")

--- a/action/config.go
+++ b/action/config.go
@@ -36,6 +36,7 @@ type service struct {
 type check struct {
 	id         string
 	http       string
+	headers    []string
 	tcp        string
 	script     string
 	ttl        string
@@ -74,6 +75,9 @@ func (c *config) addServiceFlags(f *flag.FlagSet) {
 func (c *config) addCheckFlags(f *flag.FlagSet) {
 	f.StringVar(&c.check.id, "id", "", "Service id")
 	f.StringVar(&c.check.http, "http", "", "A URL to GET every interval")
+	ssv := newStringSliceValue(&c.check.headers)
+	ssv.isCSV = false
+	f.Var(ssv, "header", "Header to be sent with HTTP Requests. Can be specified multiple times.")
 	f.StringVar(&c.check.tcp, "tcp", "", "A TCP URL to connect to every interval")
 	f.StringVar(&c.check.script, "script", "", "A script to run every interval")
 	f.StringVar(&c.check.ttl, "ttl", "", "Fail if TTL expires before service checks in")

--- a/action/map_slice.go
+++ b/action/map_slice.go
@@ -55,6 +55,14 @@ func (mv *mapValue) Set(val string) error {
 	switch mv.t {
 	case "string":
 		mv.msv.current[mv.member] = val
+	case "stringSlice":
+		if v, ok := mv.msv.current[mv.member]; ok {
+			strings, _ := readAsCSV(v.(string))
+			strings = append(strings, val)
+			mv.msv.current[mv.member], _ = writeAsCSV(strings)
+		} else {
+			mv.msv.current[mv.member] = val
+		}
 	case "bool":
 		v, err := strconv.ParseBool(val)
 		mv.msv.current[mv.member] = v

--- a/action/map_slice.go
+++ b/action/map_slice.go
@@ -57,11 +57,21 @@ func (mv *mapValue) Set(val string) error {
 		mv.msv.current[mv.member] = val
 	case "stringSlice":
 		if v, ok := mv.msv.current[mv.member]; ok {
-			strings, _ := readAsCSV(v.(string))
-			strings = append(strings, val)
-			mv.msv.current[mv.member], _ = writeAsCSV(strings)
+			stringArr, err := readAsCSV(v.(string))
+			if err != nil {
+				return err
+			}
+			stringArr = append(stringArr, val)
+			mv.msv.current[mv.member], err = writeAsCSV(stringArr)
+			if err != nil {
+				return err
+			}
 		} else {
-			mv.msv.current[mv.member], _ = writeAsCSV([]string{val})
+			var err error
+			mv.msv.current[mv.member], err = writeAsCSV([]string{val})
+			if err != nil {
+				return err
+			}
 		}
 	case "bool":
 		v, err := strconv.ParseBool(val)

--- a/action/map_slice.go
+++ b/action/map_slice.go
@@ -61,7 +61,7 @@ func (mv *mapValue) Set(val string) error {
 			strings = append(strings, val)
 			mv.msv.current[mv.member], _ = writeAsCSV(strings)
 		} else {
-			mv.msv.current[mv.member] = val
+			mv.msv.current[mv.member], _ = writeAsCSV([]string{val})
 		}
 	case "bool":
 		v, err := strconv.ParseBool(val)

--- a/action/map_slice_test.go
+++ b/action/map_slice_test.go
@@ -17,6 +17,7 @@ func testFlagSet(m *[]map[string]interface{}) *flag.FlagSet {
 	f.Var(newMapValue(mv, "stringField2", "string"), "string-field2", "String field 2")
 	f.Var(newMapValue(mv, "boolField", "bool"), "bool-field", "Bool field")
 	f.Var(newMapValue(mv, "uint64Field", "uint64"), "uint64-field", "uint64 field")
+	f.Var(newMapValue(mv, "stringSliceField", "stringSlice"), "stringslice-field", "stringslice field")
 
 	return f
 }
@@ -55,6 +56,10 @@ func TestMapSlice(t *testing.T) {
 		{
 			[]string{"--key", "--uint64-field", "123456789"},
 			[]result{{0, "uint64Field", 123456789}},
+		},
+		{
+			[]string{"--key", "--stringslice-field", "stringSlice", "--stringslice-field", "stringSlice2"},
+			[]result{{0, "stringSliceField", "stringSlice,stringSlice2"}},
 		},
 	}
 

--- a/action/service_register.go
+++ b/action/service_register.go
@@ -30,7 +30,6 @@ func (s *serviceRegister) CommandFlags() *flag.FlagSet {
 	f.Var(msv, "check", "Begin a new check definition")
 	f.Var(newMapValue(msv, "http", "string"), "http", "A URL to GET every interval")
 	f.Var(newMapValue(msv, "tcp", "string"), "tcp", "A TCP URL to connect to every interval")
-	f.Var(newMapValue(msv, "script", "string"), "script", "A script to run every interval")
 	f.Var(newMapValue(msv, "ttl", "string"), "ttl", "Fail if TTL expires before service checks in")
 	f.Var(newMapValue(msv, "interval", "string"), "interval", "Interval between checks")
 	f.Var(newMapValue(msv, "notes", "string"), "notes", "Description of the check")
@@ -92,9 +91,6 @@ func (s *serviceRegister) parseChecks() ([]*consulapi.AgentServiceCheck, error) 
 	for i, cs := range s.checks {
 		c := new(consulapi.AgentServiceCheck)
 
-		if v, ok := cs["script"]; ok {
-			c.Script = v.(string)
-		}
 		if v, ok := cs["http"]; ok {
 			c.HTTP = v.(string)
 		}

--- a/action/service_register.go
+++ b/action/service_register.go
@@ -3,6 +3,7 @@ package action
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
 )
@@ -29,6 +30,7 @@ func (s *serviceRegister) CommandFlags() *flag.FlagSet {
 
 	f.Var(msv, "check", "Begin a new check definition")
 	f.Var(newMapValue(msv, "http", "string"), "http", "A URL to GET every interval")
+	f.Var(newMapValue(msv, "headers", "stringSlice"), "header", "Header to be sent with HTTP Requests. Can be specified multiple times.")
 	f.Var(newMapValue(msv, "tcp", "string"), "tcp", "A TCP URL to connect to every interval")
 	f.Var(newMapValue(msv, "ttl", "string"), "ttl", "Fail if TTL expires before service checks in")
 	f.Var(newMapValue(msv, "interval", "string"), "interval", "Interval between checks")
@@ -85,6 +87,24 @@ func (s *serviceRegister) Run(args []string) error {
 	return nil
 }
 
+func parseHeaders(rawHeaders []string) map[string][]string {
+	var headers map[string][]string
+	headers = make(map[string][]string, len(rawHeaders))
+	for _, h := range rawHeaders {
+		header, value := parseHeader(h)
+		headers[header] = append(headers[header], value)
+	}
+	return headers
+}
+
+func parseHeader(header string) (string, string) {
+	headerParts := strings.SplitN(header, ":", 2)
+	if len(headerParts) == 2 {
+		return headerParts[0], strings.TrimSpace(headerParts[1])
+	}
+	return "", ""
+}
+
 func (s *serviceRegister) parseChecks() ([]*consulapi.AgentServiceCheck, error) {
 	rval := make([]*consulapi.AgentServiceCheck, len(s.checks))
 
@@ -93,6 +113,10 @@ func (s *serviceRegister) parseChecks() ([]*consulapi.AgentServiceCheck, error) 
 
 		if v, ok := cs["http"]; ok {
 			c.HTTP = v.(string)
+		}
+		if v, ok := cs["headers"]; ok {
+			rawHeaders, _ := readAsCSV(v.(string))
+			c.Header = parseHeaders(rawHeaders)
 		}
 		if v, ok := cs["tcp"]; ok {
 			c.TCP = v.(string)

--- a/action/string_slice.go
+++ b/action/string_slice.go
@@ -13,11 +13,13 @@ var _ = fmt.Fprint
 type stringSliceValue struct {
 	value   *[]string
 	changed bool
+	isCSV   bool
 }
 
 func newStringSliceValue(p *[]string) *stringSliceValue {
 	ssv := new(stringSliceValue)
 	ssv.value = p
+	ssv.isCSV = true
 	return ssv
 }
 
@@ -42,7 +44,15 @@ func writeAsCSV(vals []string) (string, error) {
 }
 
 func (s *stringSliceValue) Set(val string) error {
-	v, err := readAsCSV(val)
+	var v []string
+	var err error
+
+	if s.isCSV {
+		v, err = readAsCSV(val)
+	} else {
+		v = []string{val}
+	}
+
 	if err != nil {
 		return err
 	}

--- a/commands/check_test.go
+++ b/commands/check_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckRegister(t *testing.T) {
+	// wait channel for the http check
+	requestChan := make(chan struct{})
+	tested := false
+	fakeService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "testhost", r.Host)
+		assert.True(t, assert.ObjectsAreEqual([]string{"TestVal1,TestVal2"}, r.Header["X-Test-Header"]))
+		if !tested {
+			tested = true
+			requestChan <- struct{}{}
+		}
+	}))
+	defer fakeService.Close()
+
+	// register the service with `consul-cli`
+	serviceArgs := []string{"service", "register", "test-check-service", "--consul", consulTestAddr}
+	checkArgs := []string{"check", "register", "test-http-check", "--interval", "1s", "--http", fakeService.URL, "--header", "Host: testhost", "--header", "X-Test-Header: TestVal1,TestVal2"}
+
+	command := NewConsulCliCommand("consul-cli", "0.0.1")
+	command.SetArgs(serviceArgs)
+	err := command.Execute()
+	assert.Nil(t, err)
+
+	command.ResetFlags()
+
+	command.SetArgs(checkArgs)
+	err = command.Execute()
+	assert.Nil(t, err)
+
+	select {
+	case <-requestChan:
+		return
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timeout waiting for health check")
+	}
+}

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/testutil"
+)
+
+var consulTestAddr string
+
+func TestMain(m *testing.M) {
+	// create a test Consul server
+	consulTestServer, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {
+		c.Connect = nil
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	consulTestAddr = consulTestServer.HTTPAddr
+
+	exitCode := m.Run()
+	consulTestServer.Stop()
+
+	os.Exit(exitCode)
+}

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"flag"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,9 +12,17 @@ import (
 var consulTestAddr string
 
 func TestMain(m *testing.M) {
+	var consulServerOutputEnabled bool
+	flag.BoolVar(&consulServerOutputEnabled, "enable-consul-output", false, "Enables consul server output")
+
+	flag.Parse()
 	// create a test Consul server
 	consulTestServer, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {
 		c.Connect = nil
+		if !consulServerOutputEnabled {
+			c.Stderr = ioutil.Discard
+			c.Stdout = ioutil.Discard
+		}
 	})
 
 	if err != nil {

--- a/commands/service_test.go
+++ b/commands/service_test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceRegister(t *testing.T) {
+	// wait channel for the http check
+	requestChan := make(chan struct{})
+	tested := false
+	fakeService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "testhost", r.Host)
+		assert.True(t, assert.ObjectsAreEqual([]string{"TestVal1,TestVal2"}, r.Header["X-Test-Header"]))
+		if !tested {
+			tested = true
+			requestChan <- struct{}{}
+		}
+	}))
+	defer fakeService.Close()
+
+	// register the service with `consul-cli`
+	args := []string{"service", "register", "test-service",
+		"--check",
+		"--http", fakeService.URL,
+		"--header", "Host: testhost",
+		"--header", "X-Test-Header: TestVal1,TestVal2",
+		"--interval", "1s",
+		"--consul", consulTestAddr}
+
+	command := NewConsulCliCommand("consul-cli", "0.0.1")
+	command.SetArgs(args)
+	err := command.Execute()
+	assert.Nil(t, err)
+
+	select {
+	case <-requestChan:
+		return
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timeout waiting for health check")
+	}
+}


### PR DESCRIPTION
I'm using `consul-cli` to register services and wanted to add some headers to the http checks. The current solution was to use `--raw` and throw some json at it:

```shell
      consul-cli service register --raw - <<JSON
      {
        "name": "example-service",
        "port": 1337,
        "check": {
          "http": "http://localhost:1337/_ping",
          "header": { "Host": [ "example-service" ] },
          "interval": "15s"
        }
      }
JSON
```

Rather tossing JSON around it would be nice to add `--header "Header: Val"` flag support. 

This PR adds `stringSlice` support to the `mapValue` Value implementation. Currently the string slice is serializes to CSV to work the existing  implementation. 

Added the ability turn off CSV reading when setting up a `stringSliceValue`. 

With those out of the way the header flag implementation is pretty straight forward. The flag can be specified multiple times. These headers will be parsed and passed along as to the  `onsulapi.AgentServiceCheck` structs.

Added some command tests to make it easier to verify the implementation.

```
$ GOCACHE=off make test
go test $(glide nv)  -timeout=30s -parallel=4
ok  	github.com/mantl/consul-cli/action	0.011s
ok  	github.com/mantl/consul-cli/commands	3.628s
?   	github.com/mantl/consul-cli	[no test files]
go vet $(glide nv)
```